### PR TITLE
Updated branching strategy to mention the possibility of having a permanent `release` branch

### DIFF
--- a/Documentation/branching-strategy.md
+++ b/Documentation/branching-strategy.md
@@ -53,6 +53,8 @@ Once the release candidate gets greenlighted by QA we proceed to merge it into `
 
 Also, **keeping a changelog file updated is encouraged**, it will be extremely useful when updating the store and adding some *"What's new"* copy. [Read more about this here](writing-changelogs.md)
 
+✳️ In some situations, it may be appropriate and required to have a single, permanent `release` branch. For example, when using Azure DevOps for CI/CD, a branch must exist in order to define branch policies on it, to enforce the usage of pull requests, require a minimum number of reviewers, or to trigger the execution of a validation pipeline before allowing a PR to be merged.
+
 ## Tagging for releases
 
 Even when the idea is that each release that we send to the Playstore/AppStore should be saved somewhere, in case that we need to rollback the version that we pushed, we want to keep track of the release candidates, we are doing so by tagging the branches prior to the releases.

--- a/Documentation/branching-strategy.md
+++ b/Documentation/branching-strategy.md
@@ -23,33 +23,34 @@ Also, [here's another example](branching-strategy/Git-branching-model.pdf).
 Consider `master` as a reflection of "production". `master` is irreversible and stable (always compiles and tests pass).
 
 ### `development` branch
-This is where you will branch from most of the times. It's like `master` but ahead in commits since contains changes that are not "live" now. `development` is also irreversible and stable (always compiles and tests pass).
+This is where you will branch from most of the times. It's like `master` but ahead in commits since it contains changes that are not "live" now. `development` is also irreversible and stable (always compiles and tests pass).
 
 ### "Feature" branches
-Actual work will happen here. Each branch should have an item on your issue tracker, **that could be a story, a bug, an item, a ticket, whatever it is that you call it**.
+Actual work will happen here. Each branch should correspond to an entry in your issue tracker, **that could be a story, a bug, an item, a ticket, whatever it is that you call it**.
 
-Issue 32 for "Client Mobile" could be `CM-32`. We want the PR branches to match the JIRA tickets so it's easier to link them.
+Issue 32 for "Client Mobile" could be `CM-32`. We want the PR branch name to contain the issue tracker's ticket id so it's easier to link them.
 
-Before merging to `development`, it needs to be reviewed by a team member.
+Before merging to `development`, the code changes need to be reviewed by a team member.
 
-If these changes are not shipping on next release, don't merge it yet. Make the PR and put them on hold.
+If these changes are not shipping as part of the next release, don't merge them yet. Make the PR and put it on hold.
 
 ### Hot fix branches
 On rare occasions, `master` will present critical errors, or the business will require changes so urgent, that they can't go through the regular queue. For these cases, a hot fix branch can be created from `master`. Such branches should be named `hotfix_###`.
 
 These are VERY similar to _"Feature" branches_ but they are branched from `master` instead of `development`.
 
-Once the hotfix got merged into `master` we need to update the change into `development` as well. We do this by updating the `development` branch against `master` once the hotfix is merged. This way we can make sure that next time we merge a release candidate into `master` no weird conflicts are going to show up.
+Once the hotfix branch gets merged into `master` we need to propagate the changes into `development` as well. We do this by updating the `development` branch against `master` once the hotfix is merged. This way we can make sure that next time we merge a release candidate into `master` no conflicts are going to show up.
 
 ### `release` branches
-So, you made a few changes on the app and the team decided to ship a new version. In order to reach `master`, we need to test and greenlight our code. That will happen in many places, but the definitive approval must come from the release candidate branches. Release branches are code-freezed, the only changes that we will introduce (if necessary) to these branches are:
+So, you made a few changes to the app and the team decided to ship a new version. In order to reach `master`, we need to test and greenlight our code. That will happen in many places, but the definitive approval must come from the release candidate branches. Release branches are code-frozen, the only changes that we will introduce (if necessary) to these branches are:
+
 - Version bumps
 - Documentation changes (changelog files)
 - Fixes to bugs found on these branches.
 
 Release candidate branches will be named `release_{xxx.yyy.zzz}` (semver).
 
-Once the release candidate gets greenlighted by QA we proceed to merge it into `master`, once we merged the PR into `master` we update `development` against `master`.
+Once the release candidate gets greenlighted by QA, we proceed to merge it into `master`. Once the PR has been merged into `master`, we update `development` against `master`.
 
 Also, **keeping a changelog file updated is encouraged**, it will be extremely useful when updating the store and adding some *"What's new"* copy. [Read more about this here](writing-changelogs.md)
 


### PR DESCRIPTION
# What's in here

Added the mention of the possibility of having a permanent `release` branch instead of it being discardable.

Also made some miscellaneous language adjustments.